### PR TITLE
AP_Land: Paren was in wrong spot.

### DIFF
--- a/libraries/AP_Land/AP_Land.cpp
+++ b/libraries/AP_Land/AP_Land.cpp
@@ -189,7 +189,7 @@ bool AP_Land::preland_step_rally_land(const RallyLocation &ral_loc) {
  
             // Check to see if the the plane is heading toward the
             // land waypoint, with a tolerance of 3 degrees
-            if (fabs(wrap_PI(bearing - heading) <= radians(3.0f))) {
+            if (fabs(wrap_PI(bearing - heading)) <= radians(3.0f)) {
                 if(_land_heading_as_desired == false) {
                     _turns_complete++;
                 }


### PR DESCRIPTION
Paren in wrong spot resulted in plane often breaking in the wrong spot on the circle.
